### PR TITLE
SDK-1545: Convert status code to string before use in exception

### DIFF
--- a/yoti_python_sandbox/client.py
+++ b/yoti_python_sandbox/client.py
@@ -62,7 +62,8 @@ class SandboxClient(object):
 
         response_payload = signed_request.execute()
         if response_payload.status_code < 200 or response_payload.status_code >= 300:
-            raise SandboxException("Error making request to sandbox service: " + response_payload.status_code, response_payload)
+            raise SandboxException("Error making request to sandbox service: "
+                                   + str(response_payload.status_code), response_payload)
 
         parsed = json.loads(response_payload.text)
         return YotiTokenResponse(parsed["token"])

--- a/yoti_python_sandbox/tests/mocks.py
+++ b/yoti_python_sandbox/tests/mocks.py
@@ -1,0 +1,10 @@
+from yoti_python_sdk.http import YotiResponse
+
+
+class MockResponse(YotiResponse):
+    def __init__(self, status_code, text):
+        super(MockResponse, self).__init__(status_code, text)
+
+
+def mocked_request_failed_sandbox_token():
+    return MockResponse(500, "Org not found")


### PR DESCRIPTION
## Fixed

* `status_code` is now converted to a string before being used in exception message (would previously throw a `TypeError` instead of expected `SandboxException`)