### PR TITLE
SDK-1764: Exclude document fields when not set

### DIFF
--- a/yoti_python_sandbox/doc_scan/check/sandbox_document_text_data_check.py
+++ b/yoti_python_sandbox/doc_scan/check/sandbox_document_text_data_check.py
@@ -11,9 +11,6 @@ from yoti_python_sandbox.doc_scan.check.sandbox_document_check import (
 class SandboxDocumentTextDataCheckResult(SandboxCheckResult):
     def __init__(self, report, document_fields=None):
         SandboxCheckResult.__init__(self, report)
-        if document_fields is None:
-            document_fields = dict()
-
         self.__document_fields = document_fields
 
     @property
@@ -21,9 +18,12 @@ class SandboxDocumentTextDataCheckResult(SandboxCheckResult):
         return self.__document_fields
 
     def to_json(self):
-        parent = SandboxCheckResult.to_json(self)
-        parent["document_fields"] = self.document_fields
-        return parent
+        json = SandboxCheckResult.to_json(self)
+
+        if self.document_fields is not None:
+            json["document_fields"] = self.document_fields
+
+        return json
 
 
 class SandboxDocumentTextDataCheck(SandboxDocumentCheck):
@@ -35,10 +35,24 @@ class SandboxDocumentTextDataCheck(SandboxDocumentCheck):
 class SandboxDocumentTextDataCheckBuilder(SandboxDocumentCheckBuilder):
     def __init__(self):
         SandboxDocumentCheckBuilder.__init__(self)
-        self.__document_fields = {}
+        self.__document_fields = None
 
     def with_document_field(self, key, value):
+        """
+        :type key: str
+        :type value: str or dict
+        :rtype: SandboxDocumentTextDataCheckBuilder
+        """
+        self.__document_fields = self.__document_fields or {}
         self.__document_fields[key] = value
+        return self
+
+    def with_document_fields(self, document_fields):
+        """
+        :type document_fields: dict
+        :rtype: SandboxDocumentTextDataCheckBuilder
+        """
+        self.__document_fields = document_fields
         return self
 
     def build(self):

--- a/yoti_python_sandbox/doc_scan/task/sandbox_text_extraction_task.py
+++ b/yoti_python_sandbox/doc_scan/task/sandbox_text_extraction_task.py
@@ -6,9 +6,6 @@ from yoti_python_sandbox.doc_scan.document_filter import (  # noqa: F401
 
 class SandboxDocumentTextDataExtractionTaskResult(YotiSerializable):
     def __init__(self, document_fields=None):
-        if document_fields is None:
-            document_fields = dict()
-
         self.__document_fields = document_fields
 
     @property
@@ -16,7 +13,12 @@ class SandboxDocumentTextDataExtractionTaskResult(YotiSerializable):
         return self.__document_fields
 
     def to_json(self):
-        return {"document_fields": self.document_fields}
+        json = {}
+
+        if self.document_fields is not None:
+            json["document_fields"] = self.document_fields
+
+        return json
 
 
 class SandboxDocumentTextDataExtractionTask(YotiSerializable):
@@ -49,10 +51,16 @@ class SandboxDocumentTextDataExtractionTask(YotiSerializable):
 
 class SandboxDocumentTextDataExtractionTaskBuilder(object):
     def __init__(self):
-        self.__document_fields = dict()
+        self.__document_fields = None
         self.__document_filter = None
 
     def with_document_field(self, key, value):
+        """
+        :type key: str
+        :type value: str or dict
+        :rtype: SandboxDocumentTextDataExtractionTaskBuilder
+        """
+        self.__document_fields = self.__document_fields or {}
         self.__document_fields[key] = value
         return self
 
@@ -61,10 +69,14 @@ class SandboxDocumentTextDataExtractionTaskBuilder(object):
         :type document_fields: dict
         :rtype: SandboxDocumentTextDataExtractionTaskBuilder
         """
-        self.__document_fields.update(document_fields)
+        self.__document_fields = document_fields
         return self
 
     def with_document_filter(self, document_filter):
+        """
+        :type document_filter: SandboxDocumentFilter
+        :rtype: SandboxDocumentTextDataExtractionTaskBuilder
+        """
         self.__document_filter = document_filter
         return self
 

--- a/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_authenticity_check.py
+++ b/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_authenticity_check.py
@@ -12,17 +12,17 @@ def test_should_build_sandbox_document_authenticity_check():
     recommendation_mock = Mock(spec=SandboxRecommendation)
     breakdown_mock = Mock(spec=SandboxBreakdown)
 
-    result = (
+    check = (
         SandboxDocumentAuthenticityCheckBuilder()
         .with_recommendation(recommendation_mock)
         .with_breakdown(breakdown_mock)
         .build()
     )
 
-    assert result.result.report.recommendation is not None
-    assert result.result.report.recommendation == recommendation_mock
-    assert len(result.result.report.breakdown) == 1
-    assert result.result.report.breakdown[0] == breakdown_mock
+    assert check.result.report.recommendation is not None
+    assert check.result.report.recommendation == recommendation_mock
+    assert len(check.result.report.breakdown) == 1
+    assert check.result.report.breakdown[0] == breakdown_mock
 
 
 def test_should_accept_document_filter():
@@ -30,7 +30,7 @@ def test_should_accept_document_filter():
     breakdown_mock = Mock(spec=SandboxBreakdown)
     document_filter_mock = Mock(spec=SandboxDocumentFilter)
 
-    result = (
+    check = (
         SandboxDocumentAuthenticityCheckBuilder()
         .with_recommendation(recommendation_mock)
         .with_breakdown(breakdown_mock)
@@ -38,4 +38,4 @@ def test_should_accept_document_filter():
         .build()
     )
 
-    assert result.document_filter == document_filter_mock
+    assert check.document_filter == document_filter_mock

--- a/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_authenticity_check.py
+++ b/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_authenticity_check.py
@@ -26,16 +26,60 @@ def test_should_build_sandbox_document_authenticity_check():
 
 
 def test_should_accept_document_filter():
-    recommendation_mock = Mock(spec=SandboxRecommendation)
-    breakdown_mock = Mock(spec=SandboxBreakdown)
     document_filter_mock = Mock(spec=SandboxDocumentFilter)
 
     check = (
         SandboxDocumentAuthenticityCheckBuilder()
-        .with_recommendation(recommendation_mock)
-        .with_breakdown(breakdown_mock)
         .with_document_filter(document_filter_mock)
         .build()
     )
 
     assert check.document_filter == document_filter_mock
+
+
+def test_json_should_include_document_filter():
+    document_filter_mock = Mock(spec=SandboxDocumentFilter)
+
+    check = (
+        SandboxDocumentAuthenticityCheckBuilder()
+        .with_document_filter(document_filter_mock)
+        .build()
+    )
+
+    json = check.to_json()
+
+    assert json.get("document_filter") == document_filter_mock
+
+
+def test_json_includes_breakdowns():
+    breakdowns_mock = [Mock(spec=SandboxBreakdown), Mock(spec=SandboxBreakdown)]
+
+    check = (
+        SandboxDocumentAuthenticityCheckBuilder()
+        .with_breakdowns(breakdowns_mock)
+        .build()
+    )
+
+    json = check.to_json()
+
+    assert (
+        json.get("result").to_json().get("report").to_json().get("breakdown")
+        == breakdowns_mock
+    )
+
+
+def test_json_includes_recommendation():
+    recommendation_mock = Mock(spec=SandboxRecommendation)
+
+    check = (
+        SandboxDocumentAuthenticityCheckBuilder()
+        .with_recommendation(recommendation_mock)
+        .build()
+    )
+
+    json = check.to_json()
+
+    assert (
+        json.get("result").to_json().get("report").to_json().get("recommendation")
+        == recommendation_mock
+    )

--- a/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_face_match_check.py
+++ b/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_face_match_check.py
@@ -12,17 +12,17 @@ def test_should_build_sandbox_document_authenticity_check():
     recommendation_mock = Mock(spec=SandboxRecommendation)
     breakdown_mock = Mock(spec=SandboxBreakdown)
 
-    result = (
+    check = (
         SandboxDocumentFaceMatchCheckBuilder()
         .with_recommendation(recommendation_mock)
         .with_breakdown(breakdown_mock)
         .build()
     )
 
-    assert result.result.report.recommendation is not None
-    assert result.result.report.recommendation == recommendation_mock
-    assert len(result.result.report.breakdown) == 1
-    assert result.result.report.breakdown[0] == breakdown_mock
+    assert check.result.report.recommendation is not None
+    assert check.result.report.recommendation == recommendation_mock
+    assert len(check.result.report.breakdown) == 1
+    assert check.result.report.breakdown[0] == breakdown_mock
 
 
 def test_should_accept_document_filter():
@@ -30,7 +30,7 @@ def test_should_accept_document_filter():
     breakdown_mock = Mock(spec=SandboxBreakdown)
     document_filter_mock = Mock(spec=SandboxDocumentFilter)
 
-    result = (
+    check = (
         SandboxDocumentFaceMatchCheckBuilder()
         .with_recommendation(recommendation_mock)
         .with_breakdown(breakdown_mock)
@@ -38,4 +38,4 @@ def test_should_accept_document_filter():
         .build()
     )
 
-    assert result.document_filter == document_filter_mock
+    assert check.document_filter == document_filter_mock

--- a/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_face_match_check.py
+++ b/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_face_match_check.py
@@ -26,16 +26,58 @@ def test_should_build_sandbox_document_authenticity_check():
 
 
 def test_should_accept_document_filter():
-    recommendation_mock = Mock(spec=SandboxRecommendation)
-    breakdown_mock = Mock(spec=SandboxBreakdown)
     document_filter_mock = Mock(spec=SandboxDocumentFilter)
 
     check = (
         SandboxDocumentFaceMatchCheckBuilder()
-        .with_recommendation(recommendation_mock)
-        .with_breakdown(breakdown_mock)
         .with_document_filter(document_filter_mock)
         .build()
     )
 
     assert check.document_filter == document_filter_mock
+
+
+def test_json_should_include_document_filter():
+    document_filter_mock = Mock(spec=SandboxDocumentFilter)
+
+    check = (
+        SandboxDocumentFaceMatchCheckBuilder()
+        .with_document_filter(document_filter_mock)
+        .build()
+    )
+
+    json = check.to_json()
+
+    assert json.get("document_filter") == document_filter_mock
+
+
+def test_json_includes_breakdowns():
+    breakdowns_mock = [Mock(spec=SandboxBreakdown), Mock(spec=SandboxBreakdown)]
+
+    check = (
+        SandboxDocumentFaceMatchCheckBuilder().with_breakdowns(breakdowns_mock).build()
+    )
+
+    json = check.to_json()
+
+    assert (
+        json.get("result").to_json().get("report").to_json().get("breakdown")
+        == breakdowns_mock
+    )
+
+
+def test_json_includes_recommendation():
+    recommendation_mock = Mock(spec=SandboxRecommendation)
+
+    check = (
+        SandboxDocumentFaceMatchCheckBuilder()
+        .with_recommendation(recommendation_mock)
+        .build()
+    )
+
+    json = check.to_json()
+
+    assert (
+        json.get("result").to_json().get("report").to_json().get("recommendation")
+        == recommendation_mock
+    )

--- a/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_text_data_check.py
+++ b/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_text_data_check.py
@@ -12,17 +12,17 @@ def test_should_build_sandbox_document_authenticity_check():
     recommendation_mock = Mock(spec=SandboxRecommendation)
     breakdown_mock = Mock(spec=SandboxBreakdown)
 
-    result = (
+    check = (
         SandboxDocumentTextDataCheckBuilder()
         .with_recommendation(recommendation_mock)
         .with_breakdown(breakdown_mock)
         .build()
     )
 
-    assert result.result.report.recommendation is not None
-    assert result.result.report.recommendation == recommendation_mock
-    assert len(result.result.report.breakdown) == 1
-    assert result.result.report.breakdown[0] == breakdown_mock
+    assert check.result.report.recommendation is not None
+    assert check.result.report.recommendation == recommendation_mock
+    assert len(check.result.report.breakdown) == 1
+    assert check.result.report.breakdown[0] == breakdown_mock
 
 
 def test_should_accept_document_filter():
@@ -30,7 +30,7 @@ def test_should_accept_document_filter():
     breakdown_mock = Mock(spec=SandboxBreakdown)
     document_filter_mock = Mock(spec=SandboxDocumentFilter)
 
-    result = (
+    check = (
         SandboxDocumentTextDataCheckBuilder()
         .with_recommendation(recommendation_mock)
         .with_breakdown(breakdown_mock)
@@ -38,21 +38,21 @@ def test_should_accept_document_filter():
         .build()
     )
 
-    assert result.document_filter == document_filter_mock
+    assert check.document_filter == document_filter_mock
 
 
 def test_should_accept_with_breakdowns():
     recommendation_mock = Mock(spec=SandboxRecommendation)
     breakdowns_mock = [Mock(spec=SandboxBreakdown), Mock(spec=SandboxBreakdown)]
 
-    result = (
+    check = (
         SandboxDocumentTextDataCheckBuilder()
         .with_recommendation(recommendation_mock)
         .with_breakdowns(breakdowns_mock)
         .build()
     )
 
-    assert result.result.report.breakdown == breakdowns_mock
+    assert check.result.report.breakdown == breakdowns_mock
 
 
 def test_should_exclude_document_fields_when_not_set():

--- a/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_text_data_check.py
+++ b/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_text_data_check.py
@@ -53,3 +53,9 @@ def test_should_accept_with_breakdowns():
     )
 
     assert result.result.report.breakdown == breakdowns_mock
+
+
+def test_should_exclude_document_fields_when_not_set():
+    check = SandboxDocumentTextDataCheckBuilder().build()
+
+    assert check.result.document_fields is None

--- a/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_text_data_check.py
+++ b/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_text_data_check.py
@@ -55,6 +55,16 @@ def test_should_accept_with_breakdowns():
     assert check.result.report.breakdown == breakdowns_mock
 
 
+def test_should_allow_document_fields_set_with_dictionary():
+    check = (
+        SandboxDocumentTextDataCheckBuilder()
+        .with_document_fields({"someKey": "someValue"})
+        .build()
+    )
+
+    assert check.result.document_fields.get("someKey") == "someValue"
+
+
 def test_should_exclude_document_fields_when_not_set():
     check = SandboxDocumentTextDataCheckBuilder().build()
 

--- a/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_text_data_check.py
+++ b/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_document_text_data_check.py
@@ -26,14 +26,10 @@ def test_should_build_sandbox_document_authenticity_check():
 
 
 def test_should_accept_document_filter():
-    recommendation_mock = Mock(spec=SandboxRecommendation)
-    breakdown_mock = Mock(spec=SandboxBreakdown)
     document_filter_mock = Mock(spec=SandboxDocumentFilter)
 
     check = (
         SandboxDocumentTextDataCheckBuilder()
-        .with_recommendation(recommendation_mock)
-        .with_breakdown(breakdown_mock)
         .with_document_filter(document_filter_mock)
         .build()
     )
@@ -41,18 +37,60 @@ def test_should_accept_document_filter():
     assert check.document_filter == document_filter_mock
 
 
+def test_json_should_include_document_filter():
+    document_filter_mock = Mock(spec=SandboxDocumentFilter)
+
+    check = (
+        SandboxDocumentTextDataCheckBuilder()
+        .with_document_filter(document_filter_mock)
+        .build()
+    )
+
+    json = check.to_json()
+
+    assert json.get("document_filter") == document_filter_mock
+
+
 def test_should_accept_with_breakdowns():
-    recommendation_mock = Mock(spec=SandboxRecommendation)
     breakdowns_mock = [Mock(spec=SandboxBreakdown), Mock(spec=SandboxBreakdown)]
+
+    check = (
+        SandboxDocumentTextDataCheckBuilder().with_breakdowns(breakdowns_mock).build()
+    )
+
+    assert check.result.report.breakdown == breakdowns_mock
+
+
+def test_json_includes_breakdowns():
+    breakdowns_mock = [Mock(spec=SandboxBreakdown), Mock(spec=SandboxBreakdown)]
+
+    check = (
+        SandboxDocumentTextDataCheckBuilder().with_breakdowns(breakdowns_mock).build()
+    )
+
+    json = check.to_json()
+
+    assert (
+        json.get("result").to_json().get("report").to_json().get("breakdown")
+        == breakdowns_mock
+    )
+
+
+def test_json_includes_recommendation():
+    recommendation_mock = Mock(spec=SandboxRecommendation)
 
     check = (
         SandboxDocumentTextDataCheckBuilder()
         .with_recommendation(recommendation_mock)
-        .with_breakdowns(breakdowns_mock)
         .build()
     )
 
-    assert check.result.report.breakdown == breakdowns_mock
+    json = check.to_json()
+
+    assert (
+        json.get("result").to_json().get("report").to_json().get("recommendation")
+        == recommendation_mock
+    )
 
 
 def test_should_allow_document_fields_set_with_dictionary():
@@ -65,7 +103,24 @@ def test_should_allow_document_fields_set_with_dictionary():
     assert check.result.document_fields.get("someKey") == "someValue"
 
 
-def test_should_exclude_document_fields_when_not_set():
+def test_json_should_include_document_fields_when_set():
+    check = (
+        SandboxDocumentTextDataCheckBuilder()
+        .with_document_field("someKey", "someValue")
+        .build()
+    )
+
+    json = check.to_json()
+
+    assert (
+        json.get("result").to_json().get("document_fields").get("someKey")
+        == "someValue"
+    )
+
+
+def test_json_should_exclude_document_fields_when_not_set():
     check = SandboxDocumentTextDataCheckBuilder().build()
 
-    assert check.result.document_fields is None
+    json = check.to_json()
+
+    assert json.get("result").to_json().get("document_fields") is None

--- a/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_liveness_check.py
+++ b/yoti_python_sandbox/tests/doc_scan/check/test_sandbox_liveness_check.py
@@ -11,28 +11,28 @@ def test_zoom_liveness_check_should_set_correct_liveness_type():
     recommendation_mock = Mock(spec=SandboxRecommendation)
     breakdown_mock = Mock(spec=SandboxBreakdown)
 
-    result = (
+    check = (
         SandboxZoomLivenessCheckBuilder()
         .with_recommendation(recommendation_mock)
         .with_breakdown(breakdown_mock)
         .build()
     )
 
-    assert result.liveness_type == "ZOOM"
+    assert check.liveness_type == "ZOOM"
 
 
 def test_zoom_liveness_check_build_result_object():
     recommendation_mock = Mock(spec=SandboxRecommendation)
     breakdown_mock = Mock(spec=SandboxBreakdown)
 
-    result = (
+    check = (
         SandboxZoomLivenessCheckBuilder()
         .with_recommendation(recommendation_mock)
         .with_breakdown(breakdown_mock)
         .build()
     )
 
-    assert result.result.report.recommendation is not None
-    assert result.result.report.recommendation == recommendation_mock
-    assert len(result.result.report.breakdown) == 1
-    assert result.result.report.breakdown[0] == breakdown_mock
+    assert check.result.report.recommendation is not None
+    assert check.result.report.recommendation == recommendation_mock
+    assert len(check.result.report.breakdown) == 1
+    assert check.result.report.breakdown[0] == breakdown_mock

--- a/yoti_python_sandbox/tests/doc_scan/task/test_sandbox_text_extraction_task.py
+++ b/yoti_python_sandbox/tests/doc_scan/task/test_sandbox_text_extraction_task.py
@@ -39,11 +39,27 @@ def test_should_allow_multiple_document_fields():
     assert task.result.document_fields.get("someOtherKey") == "someOtherValue"
 
 
-def test_should_exclude_document_fields_when_not_set():
+def test_json_should_include_document_fields_when_set():
+    task = (
+        SandboxDocumentTextDataExtractionTaskBuilder()
+        .with_document_field("someKey", "someValue")
+        .build()
+    )
+
+    json = task.to_json()
+
+    assert (
+        json.get("result").to_json().get("document_fields").get("someKey")
+        == "someValue"
+    )
+
+
+def test_json_should_exclude_document_fields_when_not_set():
     task = SandboxDocumentTextDataExtractionTaskBuilder().build()
 
-    assert task.result.document_fields is None
-    assert task.result.to_json() == {}
+    json = task.to_json()
+
+    assert json.get("result").to_json().get("document_fields") is None
 
 
 def test_should_accept_document_filter():
@@ -56,3 +72,17 @@ def test_should_accept_document_filter():
     )
 
     assert task.document_filter == document_filter_mock
+
+
+def test_json_includes_document_filter():
+    document_filter_mock = Mock(spec=SandboxDocumentFilter)
+
+    task = (
+        SandboxDocumentTextDataExtractionTaskBuilder()
+        .with_document_filter(document_filter_mock)
+        .build()
+    )
+
+    json = task.to_json()
+
+    assert json.get("document_filter") == document_filter_mock

--- a/yoti_python_sandbox/tests/doc_scan/task/test_sandbox_text_extraction_task.py
+++ b/yoti_python_sandbox/tests/doc_scan/task/test_sandbox_text_extraction_task.py
@@ -7,23 +7,52 @@ from yoti_python_sandbox.doc_scan.task import (
 
 
 def test_should_allow_single_key_value_document_field():
-    result = (
+    task = (
         SandboxDocumentTextDataExtractionTaskBuilder()
         .with_document_field("someKey", "someValue")
         .build()
     )
 
-    assert "someKey" in result.result.document_fields
-    assert result.result.document_fields.get("someKey") == "someValue"
+    assert "someKey" in task.result.document_fields
+    assert task.result.document_fields.get("someKey") == "someValue"
+
+
+def test_should_allow_document_fields_set_with_dictionary():
+    task = (
+        SandboxDocumentTextDataExtractionTaskBuilder()
+        .with_document_fields({"someKey": "someValue"})
+        .build()
+    )
+
+    assert task.result.document_fields.get("someKey") == "someValue"
+
+
+def test_should_allow_multiple_document_fields():
+    task = (
+        SandboxDocumentTextDataExtractionTaskBuilder()
+        .with_document_field("someKey", "someValue")
+        .with_document_field("someOtherKey", "someOtherValue")
+        .build()
+    )
+
+    assert task.result.document_fields.get("someKey") == "someValue"
+    assert task.result.document_fields.get("someOtherKey") == "someOtherValue"
+
+
+def test_should_exclude_document_fields_when_not_set():
+    task = SandboxDocumentTextDataExtractionTaskBuilder().build()
+
+    assert task.result.document_fields is None
+    assert task.result.to_json() == {}
 
 
 def test_should_accept_document_filter():
     document_filter_mock = Mock(spec=SandboxDocumentFilter)
 
-    result = (
+    task = (
         SandboxDocumentTextDataExtractionTaskBuilder()
         .with_document_filter(document_filter_mock)
         .build()
     )
 
-    assert result.document_filter == document_filter_mock
+    assert task.document_filter == document_filter_mock


### PR DESCRIPTION
### Fixed
- Document fields are not included in JSON when not set

### Added
- Additional coverage for JSON properties (mapping in `to_json` methods)

Note: We may want to make use of https://github.com/getyoti/yoti-python-sdk/pull/244 once it has been released, but we should do that as a separate PR as it will involve changing unrelated `to_json` methods.